### PR TITLE
compose files to run multiple instances of netbox with shared db and redis engines

### DIFF
--- a/configuration/configuration.py
+++ b/configuration/configuration.py
@@ -261,7 +261,6 @@ PLUGINS = [
 # # Each key in the dictionary is the name of an installed plugin and its value is a dictionary of settings.
 PLUGINS_CONFIG = {
     'nextbox_ui_plugin': {
-        'INITIAL_LAYOUT': 'vertical',
         'layers_sort_order': (
             'outside',
             'border',

--- a/configuration/configuration.py
+++ b/configuration/configuration.py
@@ -261,6 +261,7 @@ PLUGINS = [
 # # Each key in the dictionary is the name of an installed plugin and its value is a dictionary of settings.
 PLUGINS_CONFIG = {
     'nextbox_ui_plugin': {
+        'INITIAL_LAYOUT': 'vertical',
         'layers_sort_order': (
             'outside',
             'border',

--- a/configuration/configuration.py
+++ b/configuration/configuration.py
@@ -277,6 +277,7 @@ PLUGINS_CONFIG = {
             'leaf',
             'access',
             'access-switch',
+            'tor-switch',
             'server',
             'host',
             'undefined',
@@ -294,6 +295,7 @@ PLUGINS_CONFIG = {
             'leaf': 'switch',
             'access': 'switch',
             'access-switch': 'switch',
+            'tor-switch': 'switch',
             'server': 'server',
             'host': 'server',
         }

--- a/configuration/configuration.py
+++ b/configuration/configuration.py
@@ -259,8 +259,46 @@ PLUGINS = [
 
 # # Plugins configuration settings. These settings are used by various plugins that the user may have installed.
 # # Each key in the dictionary is the name of an installed plugin and its value is a dictionary of settings.
-# PLUGINS_CONFIG = {
-# }
+PLUGINS_CONFIG = {
+    'nextbox_ui_plugin': {
+        'layers_sort_order': (
+            'outside',
+            'border',
+            'edge',
+            'edge-switch',
+            'edge-router',
+            'core',
+            'core-router',
+            'core-switch',
+            'distribution',
+            'distribution-router',
+            'distribution-switch',
+            'spine',
+            'leaf',
+            'access',
+            'access-switch',
+            'server',
+            'host',
+            'undefined',
+        ),
+        'icon_role_map': {
+            'border': 'router',
+            'edge-switch': 'switch',
+            'edge-router': 'router',
+            'core-router': 'router',
+            'core-switch': 'switch',
+            'distribution': 'switch',
+            'distribution-router': 'router',
+            'distribution-switch': 'switch',
+            'spine': 'switch',
+            'leaf': 'switch',
+            'access': 'switch',
+            'access-switch': 'switch',
+            'server': 'server',
+            'host': 'server',
+        }
+    }
+}
 
 # When determining the primary IP address for a device, IPv6 is preferred over IPv4 by default. Set this to True to
 # prefer IPv4 instead.

--- a/configuration/configuration.py
+++ b/configuration/configuration.py
@@ -38,7 +38,7 @@ def _environ_get_and_map(variable_name: str, default: str | None = None, map_fn:
 
     if not map_fn:
         return env_value
-    
+
     return map_fn(env_value)
 
 _AS_BOOL = lambda value : value.lower() == 'true'
@@ -253,7 +253,9 @@ if 'PAGINATE_COUNT' in environ:
     PAGINATE_COUNT = _environ_get_and_map('PAGINATE_COUNT', None, _AS_INT)
 
 # # Enable installed plugins. Add the name of each plugin to the list.
-# PLUGINS = []
+PLUGINS = [
+    'nextbox_ui_plugin'
+]
 
 # # Plugins configuration settings. These settings are used by various plugins that the user may have installed.
 # # Each key in the dictionary is the name of an installed plugin and its value is a dictionary of settings.

--- a/docker-compose-app.yml
+++ b/docker-compose-app.yml
@@ -1,0 +1,73 @@
+version: '3.4'
+services:
+  netbox: &netbox
+    image: netboxcommunity/netbox:${VERSION-v3.4-2.4.0}
+    depends_on:
+    - redis
+    - redis-cache
+    env_file: env/netbox.env
+    user: 'unit:root'
+    healthcheck:
+      start_period: 60s
+      timeout: 3s
+      interval: 15s
+      test: "curl -f http://localhost:8080/api/ || exit 1"
+    volumes:
+    - ./configuration:/etc/netbox/config:z,ro
+    - ./reports:/etc/netbox/reports:z,ro
+    - ./scripts:/etc/netbox/scripts:z,ro
+    - netbox-media-files:/opt/netbox/netbox/media:z
+  netbox-worker:
+    <<: *netbox
+    depends_on:
+      netbox:
+        condition: service_healthy
+    command:
+    - /opt/netbox/venv/bin/python
+    - /opt/netbox/netbox/manage.py
+    - rqworker
+    healthcheck:
+      start_period: 20s
+      timeout: 3s
+      interval: 15s
+      test: "ps -aux | grep -v grep | grep -q rqworker || exit 1"
+  netbox-housekeeping:
+    <<: *netbox
+    depends_on:
+      netbox:
+        condition: service_healthy
+    command:
+    - /opt/netbox/housekeeping.sh
+    healthcheck:
+      start_period: 20s
+      timeout: 3s
+      interval: 15s
+      test: "ps -aux | grep -v grep | grep -q housekeeping || exit 1"
+
+  # redis
+  redis:
+    image: redis:7-alpine
+    command:
+    - sh
+    - -c # this is to evaluate the $REDIS_PASSWORD from the env
+    - redis-server --appendonly yes --requirepass $$REDIS_PASSWORD ## $$ because of docker-compose
+    env_file: env/redis.env
+    volumes:
+    - netbox-redis-data:/data
+  redis-cache:
+    image: redis:7-alpine
+    command:
+    - sh
+    - -c # this is to evaluate the $REDIS_PASSWORD from the env
+    - redis-server --requirepass $$REDIS_PASSWORD ## $$ because of docker-compose
+    env_file: env/redis-cache.env
+    volumes:
+    - netbox-redis-cache-data:/data
+
+volumes:
+  netbox-media-files:
+    driver: local
+  netbox-redis-data:
+    driver: local
+  netbox-redis-cache-data:
+    driver: local

--- a/docker-compose-app.yml
+++ b/docker-compose-app.yml
@@ -1,6 +1,7 @@
 version: '3.4'
 services:
   netbox: &netbox
+    restart: always
     image: netboxcommunity/netbox:${VERSION-v3.4-2.4.0}
     env_file: env/netbox.env
     user: 'unit:root'

--- a/docker-compose-app.yml
+++ b/docker-compose-app.yml
@@ -2,9 +2,6 @@ version: '3.4'
 services:
   netbox: &netbox
     image: netboxcommunity/netbox:${VERSION-v3.4-2.4.0}
-    depends_on:
-    - redis
-    - redis-cache
     env_file: env/netbox.env
     user: 'unit:root'
     healthcheck:
@@ -44,30 +41,6 @@ services:
       interval: 15s
       test: "ps -aux | grep -v grep | grep -q housekeeping || exit 1"
 
-  # redis
-  redis:
-    image: redis:7-alpine
-    command:
-    - sh
-    - -c # this is to evaluate the $REDIS_PASSWORD from the env
-    - redis-server --appendonly yes --requirepass $$REDIS_PASSWORD ## $$ because of docker-compose
-    env_file: env/redis.env
-    volumes:
-    - netbox-redis-data:/data
-  redis-cache:
-    image: redis:7-alpine
-    command:
-    - sh
-    - -c # this is to evaluate the $REDIS_PASSWORD from the env
-    - redis-server --requirepass $$REDIS_PASSWORD ## $$ because of docker-compose
-    env_file: env/redis-cache.env
-    volumes:
-    - netbox-redis-cache-data:/data
-
 volumes:
   netbox-media-files:
-    driver: local
-  netbox-redis-data:
-    driver: local
-  netbox-redis-cache-data:
     driver: local

--- a/docker-compose-app.yml
+++ b/docker-compose-app.yml
@@ -14,9 +14,6 @@ services:
     - ./reports:/etc/netbox/reports:z,ro
     - ./scripts:/etc/netbox/scripts:z,ro
     - netbox-media-files:/opt/netbox/netbox/media:z
-    extra_hosts:
-      - "redis:host-gateway"
-      - "redis-cache:host-gateway"
   netbox-worker:
     <<: *netbox
     depends_on:

--- a/docker-compose-app.yml
+++ b/docker-compose-app.yml
@@ -14,6 +14,9 @@ services:
     - ./reports:/etc/netbox/reports:z,ro
     - ./scripts:/etc/netbox/scripts:z,ro
     - netbox-media-files:/opt/netbox/netbox/media:z
+    extra_hosts:
+      - "redis:host-gateway"
+      - "redis-cache:host-gateway"
   netbox-worker:
     <<: *netbox
     depends_on:

--- a/docker-compose-app.yml
+++ b/docker-compose-app.yml
@@ -2,7 +2,7 @@ version: '3.4'
 services:
   netbox: &netbox
     restart: always
-    image: netboxcommunity/netbox:${VERSION-v3.4-2.4.0}
+    image: netbox-ui:${VERSION-v3.4-2.4.0}
     env_file: env/netbox.env
     user: 'unit:root'
     healthcheck:

--- a/docker-compose-redis.yml
+++ b/docker-compose-redis.yml
@@ -10,6 +10,8 @@ services:
     env_file: env/redis.env
     volumes:
     - netbox-redis-data:/data
+    networks:
+      - redis-net
   redis-cache:
     image: redis:7-alpine
     command:
@@ -19,9 +21,16 @@ services:
     env_file: env/redis-cache.env
     volumes:
     - netbox-redis-cache-data:/data
+    networks:
+      - redis-net
 
 volumes:
   netbox-redis-data:
     driver: local
   netbox-redis-cache-data:
     driver: local
+
+networks:
+  redis-net:
+    driver: bridge
+    name: redis-net

--- a/docker-compose-redis.yml
+++ b/docker-compose-redis.yml
@@ -2,6 +2,7 @@ version: '3.4'
 services:
   # redis
   redis:
+    restart: always
     image: redis:7-alpine
     command:
     - sh
@@ -13,6 +14,7 @@ services:
     networks:
       - redis-net
   redis-cache:
+    restart: always
     image: redis:7-alpine
     command:
     - sh

--- a/docker-compose-redis.yml
+++ b/docker-compose-redis.yml
@@ -1,0 +1,27 @@
+version: '3.4'
+services:
+  # redis
+  redis:
+    image: redis:7-alpine
+    command:
+    - sh
+    - -c # this is to evaluate the $REDIS_PASSWORD from the env
+    - redis-server --appendonly yes --requirepass $$REDIS_PASSWORD ## $$ because of docker-compose
+    env_file: env/redis.env
+    volumes:
+    - netbox-redis-data:/data
+  redis-cache:
+    image: redis:7-alpine
+    command:
+    - sh
+    - -c # this is to evaluate the $REDIS_PASSWORD from the env
+    - redis-server --requirepass $$REDIS_PASSWORD ## $$ because of docker-compose
+    env_file: env/redis-cache.env
+    volumes:
+    - netbox-redis-cache-data:/data
+
+volumes:
+  netbox-redis-data:
+    driver: local
+  netbox-redis-cache-data:
+    driver: local

--- a/nbctl.sh
+++ b/nbctl.sh
@@ -12,13 +12,13 @@ optstring="u:d:h"
 
 while getopts ${optstring} arg; do
   case ${arg} in
-    s)
+    u)
       # bring up netbox docker instance
       docker-compose -f ./docker-compose-redis.yml up -d
       docker-compose -p "${OPTARG}" -f ./docker-compose-app.yml -f "/mnt/netbox/${OPTARG}/docker-compose.override.yml" up -d
       exit
       ;;
-    r)
+    d)
       # shut down netbox docker instance
       docker-compose -p "${OPTARG}" -f ./docker-compose-app.yml -f "/mnt/netbox/${OPTARG}/docker-compose.override.yml" down
       docker-compose -f ./docker-compose-redis.yml down

--- a/nbctl.sh
+++ b/nbctl.sh
@@ -14,7 +14,7 @@ while getopts ${optstring} arg; do
   case ${arg} in
     u)
       # bring up netbox docker instance
-      if "${OPTARG}" = "redis"
+      if ["${OPTARG}" = "redis"]
       then
         docker-compose -f ./docker-compose-redis.yml up -d
       else
@@ -24,7 +24,7 @@ while getopts ${optstring} arg; do
       ;;
     d)
       # shut down netbox docker instance
-      if "${OPTARG}" = "redis"
+      if ["${OPTARG}" = "redis"]
       then
         docker-compose -f ./docker-compose-redis.yml down
       else

--- a/nbctl.sh
+++ b/nbctl.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+function usage {
+  echo "Usage: $(basename $0) [-u|d] <instance> [-h]" 2>&1
+  echo '   -u <instance>  bring up netbox docker instance' 2>&1
+  echo '   -d <instance>  shut down netbox docker instance' 2>&1
+  echo '   -h         show usage' 2>&1
+}
+
+# list of arguments expected in the input
+optstring="u:d:h"
+
+while getopts ${optstring} arg; do
+  case ${arg} in
+    s)
+      # bring up netbox docker instance
+      docker-compose -f ./docker-compose-redis.yml up -d
+      docker-compose -p "${OPTARG}" -f ./docker-compose-app.yml -f "/mnt/netbox/${OPTARG}/docker-compose.override.yml" up -d
+      ;;
+    r)
+      # shut down netbox docker instance
+      docker-compose -p "${OPTARG}" -f ./docker-compose-app.yml -f "/mnt/netbox/${OPTARG}/docker-compose.override.yml" down
+      docker-compose -f ./docker-compose-redis.yml down
+      ;;
+    h)
+      usage
+      exit
+      ;;
+    ?)
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+

--- a/nbctl.sh
+++ b/nbctl.sh
@@ -16,11 +16,13 @@ while getopts ${optstring} arg; do
       # bring up netbox docker instance
       docker-compose -f ./docker-compose-redis.yml up -d
       docker-compose -p "${OPTARG}" -f ./docker-compose-app.yml -f "/mnt/netbox/${OPTARG}/docker-compose.override.yml" up -d
+      exit
       ;;
     r)
       # shut down netbox docker instance
       docker-compose -p "${OPTARG}" -f ./docker-compose-app.yml -f "/mnt/netbox/${OPTARG}/docker-compose.override.yml" down
       docker-compose -f ./docker-compose-redis.yml down
+      exit
       ;;
     h)
       usage
@@ -33,4 +35,5 @@ while getopts ${optstring} arg; do
   esac
 done
 
-
+usage
+exit 2

--- a/nbctl.sh
+++ b/nbctl.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 function usage {
   echo "Usage: $(basename $0) [-u|d] <instance> [-h]" 2>&1

--- a/nbctl.sh
+++ b/nbctl.sh
@@ -14,14 +14,22 @@ while getopts ${optstring} arg; do
   case ${arg} in
     u)
       # bring up netbox docker instance
-      docker-compose -f ./docker-compose-redis.yml up -d
-      docker-compose -p "${OPTARG}" -f ./docker-compose-app.yml -f "/mnt/netbox/${OPTARG}/docker-compose.override.yml" up -d
+      if "${OPTARG}" = "redis"
+      then
+        docker-compose -f ./docker-compose-redis.yml up -d
+      else
+        docker-compose -p "${OPTARG}" -f ./docker-compose-app.yml -f "/mnt/netbox/${OPTARG}/docker-compose.override.yml" up -d
+      fi
       exit
       ;;
     d)
       # shut down netbox docker instance
-      docker-compose -p "${OPTARG}" -f ./docker-compose-app.yml -f "/mnt/netbox/${OPTARG}/docker-compose.override.yml" down
-      docker-compose -f ./docker-compose-redis.yml down
+      if "${OPTARG}" = "redis"
+      then
+        docker-compose -f ./docker-compose-redis.yml down
+      else
+        docker-compose -p "${OPTARG}" -f ./docker-compose-app.yml -f "/mnt/netbox/${OPTARG}/docker-compose.override.yml" down
+      fi
       exit
       ;;
     h)

--- a/nbctl.sh
+++ b/nbctl.sh
@@ -14,7 +14,7 @@ while getopts ${optstring} arg; do
   case ${arg} in
     u)
       # bring up netbox docker instance
-      if ["${OPTARG}" = "redis"]
+      if [ "${OPTARG}" = "redis" ]
       then
         docker-compose -f ./docker-compose-redis.yml up -d
       else
@@ -24,7 +24,7 @@ while getopts ${optstring} arg; do
       ;;
     d)
       # shut down netbox docker instance
-      if ["${OPTARG}" = "redis"]
+      if [ "${OPTARG}" = "redis" ]
       then
         docker-compose -f ./docker-compose-redis.yml down
       else


### PR DESCRIPTION
## New Behavior

Ability run run multiple instances of netbox with shared postrgesql and redis infrastructure.

1. Have PostrgreSQL up and running, with DBs created and configured for each instance.
2. Create `/mnt/netbox/INSTANCE/docker-compose.override.yml` and `/mnt/netbox/INSTANCE/netbox.env` for each `INSTANCE`. For example, if `INSTANCE = main`

```
version: '3.4'
services:
  netbox:
    ports:
      - 8001:8080
    env_file: /mnt/netbox/main/netbox.env
    networks:
      - redis-net
  netbox-worker:
    env_file: /mnt/netbox/main/netbox.env
    networks:
      - redis-net
  netbox-housekeeping:
    env_file: /mnt/netbox/main/netbox.env
    networks:
      - redis-net

networks:
  redis-net:
    driver: bridge
    name: redis-net
```

3. To start:

```Shell
./nbctl.sh -u redis
./nbctl.sh -u instance1
./nbctl.sh -u instance2
```

4. To stop:

```Shell
./nbctl.sh -d instance1
./nbctl.sh -d instance2
./nbctl.sh -d redis
```
